### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ the JavaScript side, which defaults to 10000 milliseconds (10 seconds). This can
 
 #### Callbacks
 
-When you call an exposed function, you can immediately pass a callback function afterwards. This callback will automatically be called asynchrounously with the return value when the function has finished executing on the other side.
+When you call an exposed function, you can immediately pass a callback function afterwards. This callback will automatically be called asynchronous with the return value when the function has finished executing on the other side.
 
 For example, if we have the following function defined and exposed in Javascript:
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ the JavaScript side, which defaults to 10000 milliseconds (10 seconds). This can
 
 #### Callbacks
 
-When you call an exposed function, you can immediately pass a callback function afterwards. This callback will automatically be called asynchronous with the return value when the function has finished executing on the other side.
+When you call an exposed function, you can immediately pass a callback function afterwards. This callback will automatically be called asynchronously with the return value when the function has finished executing on the other side.
 
 For example, if we have the following function defined and exposed in Javascript:
 

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -54,7 +54,7 @@ _start_args = {
     'shutdown_delay': 1.0                          # how long to wait after a websocket closes before detecting complete shutdown
 }
 
-# == Temporary (suppressable) error message to inform users of breaking API change for v1.0.0 ===
+# == Temporary (suppressible) error message to inform users of breaking API change for v1.0.0 ===
 _start_args['suppress_error'] = False
 api_error_message = '''
 ----------------------------------------------------------------------------------


### PR DESCRIPTION
There are small typos in:
- README.md
- eel/__init__.py

Fixes:
- Should read `suppressible` rather than `suppressable`.
- Should read `asynchronous` rather than `asynchrounously`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md