### PR TITLE
Bump to v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### v0.15.0
+* Add `shutdown_delay` as a `start()` function parameter ([#529](https://github.com/python-eel/Eel/pull/529))
+
 ### v0.14.0
 * Change JS function name parsing to use PyParsing rather than regex, courtesy @KyleKing.
 

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ with open('README.md') as read_me:
 
 setup(
     name='Eel',
-    version='0.14.0',
-    author='Chris Knott',
-    author_email='chrisknott@hotmail.co.uk',
-    url='https://github.com/samuelhwilliams/Eel',
+    version='0.15.0',
+    author='Python Eel Organisation',
+    author_email='python-eel@protonmail.com',
+    url='https://github.com/python-eel/Eel',
     packages=['eel'],
     package_data={
         'eel': ['eel.js'],


### PR DESCRIPTION
As discussed in https://github.com/python-eel/Eel/pull/529, bump up to v0.15.0 in preparation for a release.

As also discussed https://github.com/python-eel/Eel/issues/600, this PR includes updates for the Python Eel Organisation (@samuelhwilliams - I asked @ChrisKnott to forward you an email related to the new email account). 