### PR TITLE
get_real_path() fix for cx-freeze

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -312,7 +312,7 @@ def _process_message(message, ws):
 
 
 def _get_real_path(path):
-    if getattr(sys, 'frozen', False):
+    if getattr(sys, 'frozen', False) and hasattr(sys, "_MEIPASS"):
         return os.path.join(sys._MEIPASS, path)
     else:
         return os.path.abspath(path)

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -314,6 +314,8 @@ def _process_message(message, ws):
 def _get_real_path(path):
     if getattr(sys, 'frozen', False) and hasattr(sys, "_MEIPASS"):
         return os.path.join(sys._MEIPASS, path)
+    elif getattr(sys, 'frozen', False):
+        return os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), path)
     else:
         return os.path.abspath(path)
 


### PR DESCRIPTION
Currently only implemented for pyinstaller. This is update for cx-freeze.