### PR TITLE
Bump bottle from v0.12.13 to v0.12.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### v0.15.1
+* Bump bottle dependency from 0.12.13 to 0.12.20 to address the critical CVE-2022-31799 and moderate CVE-2020-28473.
+
 ### v0.15.0
 * Add `shutdown_delay` as a `start()` function parameter ([#529](https://github.com/python-eel/Eel/pull/529))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bottle==0.12.13
+bottle==0.12.20
 bottle-websocket==0.2.9
 gevent==1.3.6
 gevent-websocket==0.10.1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as read_me:
 
 setup(
     name='Eel',
-    version='0.15.0',
+    version='0.15.1',
     author='Python Eel Organisation',
     author_email='python-eel@protonmail.com',
     url='https://github.com/python-eel/Eel',


### PR DESCRIPTION
Addresses two CVEs flagged by dependabot:

* Critical: CVE-2022-31799
* Moderate: CVE-2020-28473