### PR TITLE
Increase initialisation speed by optionally excluding files to scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ This will start a webserver on the default settings (http://localhost:8000) and 
 
 If Chrome or Chromium is installed then by default it will open in that in App Mode (with the `--app` cmdline flag), regardless of what the OS's default browser is set to (it is possible to override this behaviour).
 
+If you have alrge amounts of .html or .js files, eel.init() might take up a long time to scan those files for exposed functions. By passing a list of paths to the init function's exclude_path parameter you can exclude these files from being scanned.  
+
 ### App options
 
 Additional options can be passed to `eel.start()` as keyword arguments.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This will start a webserver on the default settings (http://localhost:8000) and 
 
 If Chrome or Chromium is installed then by default it will open in that in App Mode (with the `--app` cmdline flag), regardless of what the OS's default browser is set to (it is possible to override this behaviour).
 
-If you have alrge amounts of .html or .js files, eel.init() might take up a long time to scan those files for exposed functions. By passing a list of paths to the init function's exclude_path parameter you can exclude these files from being scanned.  
+If you have large amounts of .html or .js files, eel.init() might take up a long time to scan those files for exposed functions. By passing a list of paths to the init function's exclude_path parameter you can exclude these files from being scanned.  
 
 ### App options
 

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -111,7 +111,7 @@ EXPOSED_JS_FUNCTIONS: pp.ZeroOrMore = pp.ZeroOrMore(
 
 
 def init(path: str, allowed_extensions: List[str] = ['.js', '.html', '.txt', '.htm',
-                                   '.xhtml', '.vue'], js_result_timeout: int = 10000) -> None:
+                                   '.xhtml', '.vue'], exclude_path: List[str] = [], js_result_timeout: int = 10000) -> None:
     global root_path, _js_functions, _js_result_timeout
     root_path = _get_real_path(path)
 
@@ -119,6 +119,10 @@ def init(path: str, allowed_extensions: List[str] = ['.js', '.html', '.txt', '.h
     for root, _, files in os.walk(root_path):
         for name in files:
             if not any(name.endswith(ext) for ext in allowed_extensions):
+                continue
+
+            # exclude specific file paths to increase loading speed on initialisation
+            if any(exclude in os.path.join(root, name) for exclude in exclude_path):
                 continue
 
             try:


### PR DESCRIPTION
This PR solves an issue with slow loading eel applications by offering the developer the option to exclude file paths from the EXPOSED_JS_FUNCTIONS scan.

Instead of just scanning all .html, .js and .txt files, the developer can exclude file paths containing any of the strings passed trough the exclude_path parameter.

In a typical html template, there are lots of javascript files that add GUI functionalities, and in one case this added up to 120 seconds when using the current init command.
eel.init('web') took 122.60855889320374 seconds

assuming all external javascript files are in the web/plugins directory, changing to the new option:
eel.init('web', exclude_path=['web/plugins']) took 1.013951301574707 seconds