### PR TITLE
bottle.websocket has changed to bottle_websocket

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -13,7 +13,7 @@ from gevent.threading import Timer
 import gevent as gvt
 import json as jsn
 import bottle as btl
-import bottle.ext.websocket as wbs
+import bottle_websocket as wbs
 import re as rgx
 import os
 import eel.browsers as brw


### PR DESCRIPTION
This was the change I had to make to get a recent install of eel working.