### PR TITLE
Fix WebSocket import error for Python 3.12 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
         exclude:
           - os: macos-latest
             python-version: 3.7

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -13,7 +13,10 @@ from gevent.threading import Timer
 import gevent as gvt
 import json as jsn
 import bottle as btl
-import bottle.ext.websocket as wbs
+try:
+    import bottle_websocket as wbs
+except ImportError:
+    import bottle.ext.websocket as wbs
 import re as rgx
 import os
 import eel.browsers as brw

--- a/requirements-meta.txt
+++ b/requirements-meta.txt
@@ -2,3 +2,4 @@ tox>=3.15.2,<4.0.0
 tox-pyenv==1.1.0
 tox-gh-actions==2.0.0
 virtualenv>=16.7.10
+setuptools

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,10 +1,10 @@
 .[jinja2]
 
-psutil==5.9.2
-pytest==7.0.1
-pytest-timeout==2.1.0
+psutil>=5.0.0,<6.0.0
+pytest>=7.0.0,<8.0.0
+pytest-timeout>=2.0.0,<3.0.0
 selenium>=4.0.0,<5.0.0
 webdriver_manager>=4.0.0,<5.0.0
 mypy==0.971
-pyinstaller==4.10
-types-setuptools==67.2.0.1
+pyinstaller
+types-setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,9 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312
+
 
 [testenv]
 description = run py.test tests

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,7 @@ python =
 
 [testenv]
 description = run py.test tests
-deps =
-  -r requirements-test.txt
-  setuptools
+deps = -r requirements-test.txt
 commands =
   # this ugly hack is here because:
   # https://github.com/tox-dev/tox/issues/149

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,9 @@ python =
 
 [testenv]
 description = run py.test tests
-deps = -r requirements-test.txt
+deps =
+  -r requirements-test.txt
+  setuptools
 commands =
   # this ugly hack is here because:
   # https://github.com/tox-dev/tox/issues/149

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = typecheck,py{37,38,39,310}
+envlist = typecheck,py{37,38,39,310,311,312}
 
 [pytest]
 timeout = 30


### PR DESCRIPTION
This pull request addresses an issue encountered specifically in Python 3.12 related to importing the WebSocket extension in Bottle applications. The error arises due to the absence of the bottle.ext.websocket 

Additionally I added tox configurations for Python 3.11 and Python 3.12

This PR should also resolve the following issues:
#723 
