### PR TITLE
Added app mode support for micorsoft  edge, IE mode for internet explorer and increase timeout for test run.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup test execution environment.
         run: pip3 install -r requirements-meta.txt
       - name: Run tox tests
-        run: tox -- --durations=0 --timeout=30
+        run: tox -- --durations=0 --timeout=60
 
   typecheck:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
         exclude:
           - os: macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup test execution environment.
         run: pip3 install -r requirements-meta.txt
       - name: Run tox tests
-        run: tox -- --durations=0 --timeout=120
+        run: tox -- --durations=0 --timeout=240
 
   typecheck:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup test execution environment.
         run: pip3 install -r requirements-meta.txt
       - name: Run tox tests
-        run: tox -- --durations=0 --timeout=60
+        run: tox -- --durations=0 --timeout=120
 
   typecheck:
     strategy:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Additional options can be passed to `eel.start()` as keyword arguments.
 Some of the options include the mode the app is in (e.g. 'chrome'), the port the app runs on, the host name of the app, and adding additional command line flags.
 
 As of Eel v0.12.0, the following options are available to `start()`:
- - **mode**, a string specifying what browser to use (e.g. `'chrome'`, `'electron'`, `'edge'`, `'custom'`). Can also be `None` or `False` to not open a window. *Default: `'chrome'`*
+ - **mode**, a string specifying what browser to use (e.g. `'chrome'`, `'electron'`, `'edge'`,`'msie'`, `'custom'`). Can also be `None` or `False` to not open a window. *Default: `'chrome'`*
  - **host**, a string specifying what hostname to use for the Bottle server. *Default: `'localhost'`)*
  - **port**, an int specifying what port to use for the Bottle server. Use `0` for port to be picked automatically. *Default: `8000`*.
  - **block**, a bool saying whether or not the call to `start()` should block the calling thread. *Default: `True`*

--- a/eel/browsers.py
+++ b/eel/browsers.py
@@ -7,13 +7,15 @@ from eel.types import OptionsDictT
 import eel.chrome as chm
 import eel.electron as ele
 import eel.edge as edge
+import eel.msIE as ie
 #import eel.firefox as ffx      TODO
 #import eel.safari as saf       TODO
 
 _browser_paths: Dict[str, str] = {}
 _browser_modules: Dict[str, ModuleType] = {'chrome':   chm,
                                            'electron': ele,
-                                           'edge': edge}
+                                           'edge': edge,
+                                           'msie':ie}
 
 
 def _build_url_from_dict(page: Dict[str, str], options: OptionsDictT) -> str:

--- a/eel/edge.py
+++ b/eel/edge.py
@@ -9,9 +9,16 @@ name: str = 'Edge'
 
 
 def run(_path: str, options: OptionsDictT, start_urls: List[str]) -> None:
-    cmd = 'start microsoft-edge:{}'.format(start_urls[0])
-    sps.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, stdin=sps.PIPE, shell=True)
-
+    if not isinstance(options['cmdline_args'], list):
+        raise TypeError("'cmdline_args' option must be of type List[str]")
+    args: List[str] = options['cmdline_args']
+    if options['app_mode']:
+        cmd = 'start msedge --app={} '.format(start_urls[0])
+        cmd = cmd + (" ".join(args))
+        sps.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, stdin=sps.PIPE, shell=True)
+    else:
+        cmd = "start msedge --new-window "+(" ".join(args)) +" "+(start_urls[0])
+        sps.Popen(cmd,stdout=sys.stdout, stderr=sys.stderr, stdin=sps.PIPE, shell=True)
 
 def find_path() -> bool:
     if platform.system() == 'Windows':

--- a/eel/msIE.py
+++ b/eel/msIE.py
@@ -1,0 +1,20 @@
+import platform
+import subprocess as sps
+import sys
+from typing import List
+
+from eel.types import OptionsDictT
+
+name: str = 'MSIE'
+
+
+def run(_path: str, options: OptionsDictT, start_urls: List[str]) -> None:
+    cmd = 'start microsoft-edge:{}'.format(start_urls[0])
+    sps.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, stdin=sps.PIPE, shell=True)
+
+
+def find_path() -> bool:
+    if platform.system() == 'Windows':
+        return True
+
+    return False


### PR DESCRIPTION
Added MSIE mode to support device which does not have edge installed by default ( win <10).

Added support in edge to support edge mode or new window mode if app mode is not requested

tux test timeout updated as windows on GA was always failing with timeout. 