### PR TITLE
Fix JS memory leak + modernize `eel.js`

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -423,10 +423,10 @@ def _eel() -> str:
                                   'position': _start_args['position']},
                       'pages':   _start_args['geometry']}
 
-    page = _eel_js.replace('/** _py_functions **/',
-                           '_py_functions: %s,' % list(_exposed_functions.keys()))
-    page = page.replace('/** _start_geometry **/',
-                        '_start_geometry: %s,' % _safe_json(start_geometry))
+    page = _eel_js.replace('#py_functions // Injected by Python',
+                           '#py_functions = %s;' % list(_exposed_functions.keys()))
+    page = page.replace('#start_geometry // Injected by Python',
+                        '#start_geometry = %s;' % _safe_json(start_geometry))
     btl.response.content_type = 'application/javascript'
     _set_response_headers(btl.response)
     return page

--- a/eel/eel.js
+++ b/eel/eel.js
@@ -31,14 +31,12 @@ class Eel {
     #mock_queue = [];
 
     #mock_py_functions() {
-        for (let i = 0; i < this.#py_functions.length; i++) {
-            const name = this.#py_functions[i];
+        for (let name of this.#py_functions)
             this[name] = function() {
                 const call_object = this.#call_object(name, arguments);
                 this.#mock_queue.push(call_object);
                 return this.#call_return(call_object);
-            }
-        }
+            };
     }
 
     #import_py_function(name) {
@@ -53,13 +51,11 @@ class Eel {
 
     #call_return_callbacks = {};
 
-    #call_object(name, args) {
-        const arg_array = [];
-        for (let i = 0; i < args.length; i++)
-            arg_array.push(args[i]);
-        const call_id = (this.#call_number += 1) + Math.random();
-        return {'call': call_id, 'name': name, 'args': arg_array};
-    }
+    #call_object = (name, args) => ({
+        'call': (this.#call_number += 1) + Math.random(),
+        'name': name,
+        'args': [...args]
+    });
 
     #sleep(ms) {
         return new Promise(resolve => setTimeout(resolve, ms));
@@ -109,10 +105,8 @@ class Eel {
             this.#websocket = new WebSocket(websocket_addr);
 
             this.#websocket.onopen = () => {
-                for (let i = 0; i < this.#py_functions.length; i++) {
-                    const py_function = this.#py_functions[i];
-                    this.#import_py_function(py_function);
-                }
+                for (let func_name of this.#py_functions)
+                    this.#import_py_function(func_name);
                 while (this.#mock_queue.length > 0) {
                     const call = this.#mock_queue.shift();
                     this.#websocket.send(this.#to_json(call));

--- a/eel/eel.js
+++ b/eel/eel.js
@@ -148,9 +148,11 @@ eel = {
                     if(message['return'] in eel._call_return_callbacks) {
                         if(message['status']==='ok'){
                             eel._call_return_callbacks[message['return']].resolve(message.value);
+                            delete eel._call_return_callbacks[message['return']];
                         }
                         else if(message['status']==='error' &&  eel._call_return_callbacks[message['return']].reject) {
-                                eel._call_return_callbacks[message['return']].reject(message['error']);
+                            eel._call_return_callbacks[message['return']].reject(message['error']);
+                            delete eel._call_return_callbacks[message['return']];
                         }
                     }
                 } else {


### PR DESCRIPTION
Seeing `eel.js` for the memory leak fix, I felt its readability could be improved, so I proceed.

I tested it against Python 3.10.16 on Linux. I had to modify `conftest.py` to use Chromium instead of Chrome. Maybe it would be nice to include such a modification to not force to install Chrome.

If we go ahead, I may want to refactor and modernize `eel.js` more for concision leading to better maintainability. Is there any rules of ordering classes elements you would like to favor ?