### PR TITLE
#765 Drop pkg_resources

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -18,14 +18,20 @@ import eel.browsers as brw
 import pyparsing as pp
 import random as rnd
 import sys
-import pkg_resources as pkg
+import importlib_resources
 import socket
 import mimetypes
 
 
 mimetypes.add_type('application/javascript', '.js')
-_eel_js_file: str = pkg.resource_filename('eel', 'eel.js')
-_eel_js: str = open(_eel_js_file, encoding='utf-8').read()
+
+# https://setuptools.pypa.io/en/latest/pkg_resources.html
+#     Use of pkg_resources is deprecated in favor of importlib.resources
+# Migration guide: https://importlib-resources.readthedocs.io/en/latest/migration.html
+_eel_js_reference = importlib_resources.files('eel') / 'eel.js'
+with importlib_resources.as_file(_eel_js_reference) as _eel_js_path:
+    _eel_js: str = _eel_js_path.read_text(encoding='utf-8')
+
 _websockets: List[Tuple[Any, WebSocketT]] = []
 _call_return_values: Dict[Any, Any] = {}
 _call_return_callbacks: Dict[float, Tuple[Callable[..., Any], Optional[Callable[..., Any]]]] = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ gevent-websocket<1.0.0
 greenlet>=1.0.0,<2.0.0
 pyparsing>=3.0.0,<4.0.0
 typing-extensions>=4.3.0
+importlib_resources>=1.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = typecheck,py{37,38,39,310,311,312}
+envlist = typecheck,py{37,38,39,310,311,312,313}
 
 [pytest]
 timeout = 30
@@ -12,6 +12,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 
 [testenv]


### PR DESCRIPTION
Closes #765

1. Used `importlib_resources` instead of `pkg_resources` as per migration guide.
2. Added python 3.13 support to `tox.ini`.

I did not use std `importlib.resources` to support older python versions. The minimum required `importlib-resources` 1.3 implements `importlib.resources` from python 3.9 and should work correctly for Python 3.5+ and 2.7+.
